### PR TITLE
fix: replace raw echo with standard output helpers in github/cancel-workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace raw echo with output helpers in linux/install-fp
 ### Changed
 - GEOIP - Updated GEOIP DB from MaxMind (2026-06-03)
+- Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/github/cancel-workflows
+++ b/github/cancel-workflows
@@ -1,13 +1,16 @@
-#!/bin/bash
-
-info() {
-    echo "$@"
-}
+#!/bin/sh
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 BASEDIR="$(dirname "$(readlink -f "$0")")"
@@ -65,3 +68,5 @@ EOF
 
         info "Total $c in this batch"
 done
+
+success "All queued workflows cancelled"


### PR DESCRIPTION
## Summary

- Replace the custom inline `info()` and `die()` functions with the standard project output helpers (`die`, `info`, `success`), using coloured `printf`-based output per `shell-scripts.examples.md`
- Add `success` call at end of script to confirm completion
- Change shebang from `#!/bin/bash` to `#!/bin/sh` (no bash-specific features used)

Closes #653

## Test plan

- [ ] `shellcheck github/cancel-workflows` passes
- [ ] `checkbashisms github/cancel-workflows` passes
- [ ] Pre-commit hooks pass