### PR TITLE
fix: replace raw echo with standard output helpers in git/update-repos-personal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Changed
 - GEOIP - Updated GEOIP DB from MaxMind (2026-06-03)
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
+- Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal
 ### Deprecated
 ### Removed
 ### Deployment Changes

--- a/git/update-repos-personal
+++ b/git/update-repos-personal
@@ -1,14 +1,20 @@
-#! /bin/sh
-
+#!/bin/sh
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
 }
 
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
 BASEDIR="$(dirname "$(readlink -f "$0")")"
-echo "Script Dir: $BASEDIR"
+info "Script Dir: $BASEDIR"
 
 REPOS=personal
 WORKDIR=$HOME/work/$REPOS

--- a/git/update-repos-personal
+++ b/git/update-repos-personal
@@ -5,10 +5,6 @@ die() {
     exit 1
 }
 
-success() {
-    printf '\n\033[32m✓\033[0m %s\n' "$*"
-}
-
 info() {
     printf '\n\033[32m→\033[0m %s\n' "$*"
 }


### PR DESCRIPTION
## Summary

- Fix shebang spacing (`#! /bin/sh` → `#!/bin/sh`)
- Replace the non-standard `die()` function with the project-standard implementation using coloured `printf` output directed to stderr
- Add `info()` helper function and replace raw `echo "Script Dir: $BASEDIR"` with `info "Script Dir: $BASEDIR"`

Closes #652

## Test plan

- [x] shellcheck passes on the updated script
- [x] checkbashisms passes on the updated script
- [x] Script behaviour is preserved — only output formatting changed