### PR TITLE
fix: replace raw echo with standard output helpers in git/update-preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Shell scripts were cleaned up to pass pre-commit checks, and git/fetch now uses consistent info/success output.
 - Replace raw echo output with standard die/success/info helpers in network/wg-create
 - Replace raw echo with output helpers in linux/install-fp
+- Replace raw echo with output helpers in git/update-preview
 ### Changed
 - GEOIP - Updated GEOIP DB from MaxMind (2026-06-03)
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows

--- a/git/update-preview
+++ b/git/update-preview
@@ -1,9 +1,16 @@
 #! /bin/sh
 
 die() {
-    echo
-    echo "$@"
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
     exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
 }
 
 BASEDIR="$(dirname "$(readlink -f "$0")")"
@@ -15,6 +22,6 @@ BASEDIR="$(dirname "$(readlink -f "$0")")"
 
 BRANCH="depends/sdk/dotnet/$DOTNET_PREVIEW_VERSION/preview"
 
-echo "Using Branch: $BRANCH"
+info "Using Branch: $BRANCH"
 
 git fetch && git checkout main && git pull && git checkout "$BRANCH" && git pull && rebase && update-dotnet-sdk


### PR DESCRIPTION
## Summary

- Replace the custom `die()` stub with the standard `die`, `success`, and `info` output helpers from the project shell-script rules
- Replace `echo "Using Branch: $BRANCH"` with `info "Using Branch: $BRANCH"`
- Script behaviour is fully preserved

Closes #651

## Test plan

- [ ] shellcheck passes on `git/update-preview`
- [ ] All pre-commit hooks pass
- [ ] Script output uses coloured helpers (`→`, `✗`) instead of bare echo