### PR TITLE
fix: replace raw echo with output helpers in git/optimise-git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace raw echo with output helpers in git/update-preview
 - Replace raw echo with standard output helpers in git/update-dotnet-sdk
 - Replace raw echo with standard output helpers in git/switchtomain
+- Replace raw echo with output helpers in git/optimise-git
 ### Changed
 - GEOIP - Updated GEOIP DB from MaxMind (2026-06-03)
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows

--- a/git/optimise-git
+++ b/git/optimise-git
@@ -1,30 +1,41 @@
-#! /bin/sh
+#!/bin/sh
 
-echo "PWD: $(pwd)"
+die() {
+    printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    exit 1
+}
+
+success() {
+    printf '\n\033[32m✓\033[0m %s\n' "$*"
+}
+
+info() {
+    printf '\n\033[32m→\033[0m %s\n' "$*"
+}
+
+info "PWD: $(pwd)"
 
 find "$(pwd)"/* -name '*.git' -print | sed "s|/.git$||" | sort -u | grep -v .cache | while IFS= read -r line
 do
-  echo "$line"
   CURRENT_DIR=$line
 
-echo ""
-  echo "Optimising $CURRENT_DIR..."
+  info "Optimising ${CURRENT_DIR}..."
 
-  echo "* Pruning remotes..."
+  info "Pruning remotes..."
   for REMOTE in $(git -C "$CURRENT_DIR" remote)
   do
-    echo "  + Pruning $REMOTE..."
+    info "Pruning ${REMOTE}..."
     git -C "$CURRENT_DIR" remote prune "$REMOTE"
   done
 
-  echo "* Repacking..."
+  info "Repacking..."
   git -C "$CURRENT_DIR" repack
-  echo "* Pruning packed..."
+  info "Pruning packed..."
   git -C "$CURRENT_DIR" prune-packed
-  echo "* Expiring reflog..."
+  info "Expiring reflog..."
   git -C "$CURRENT_DIR" reflog expire --expire=1.month.ago
-  echo "*Garbage collecting..."
+  info "Garbage collecting..."
   git -C "$CURRENT_DIR" gc --aggressive --prune 2>&1
 
-  echo " * done"
+  success "Done with ${CURRENT_DIR}"
 done


### PR DESCRIPTION
## Summary

- Replace all user-facing raw `echo` calls in `git/optimise-git` with the standard output helpers (`die`, `info`, `success`)
- Add the output helper function definitions at the top of the script
- Fix shebang spacing (`#! /bin/sh` → `#!/bin/sh`) for consistency
- Preserve all existing script behaviour

Closes #648

## Test plan

- [ ] Run `shellcheck git/optimise-git` — should pass with no warnings
- [ ] Verify the script executes correctly against a directory tree of git repos
- [ ] Confirm all pre-commit checks pass (they passed in CI during commit)