### PR TITLE
fix: replace raw echo with output helpers in development/sln-migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace raw echo with output helpers in general/install-latest-dotnet
 - Replaced raw echo with output helpers in general/install-dotnet-tools
 - Replace raw echo with output helpers in general/convert-video
+- Replace raw echo with output helpers in development/sln-migrate
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/development/sln-migrate
+++ b/development/sln-migrate
@@ -1,11 +1,29 @@
 #! /bin/sh
 
 die() {
-    echo
-    echo "$@"
+    if [ -t 2 ]; then
+        printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    else
+        printf '\n✗ %s\n' "$*" >&2
+    fi
     exit 1
 }
 
+success() {
+    if [ -t 1 ]; then
+        printf '\n\033[32m✓\033[0m %s\n' "$*"
+    else
+        printf '\n✓ %s\n' "$*"
+    fi
+}
+
+info() {
+    if [ -t 1 ]; then
+        printf '\n\033[32m→\033[0m %s\n' "$*"
+    else
+        printf '\n→ %s\n' "$*"
+    fi
+}
 
 LEGACY_SOLUTION=$(find "$PWD" -type f -iname "*.sln" | head -1)
 [ -z "$LEGACY_SOLUTION" ] && die "No Solution found in $(pwd)"
@@ -13,16 +31,17 @@ LEGACY_SOLUTION=$(find "$PWD" -type f -iname "*.sln" | head -1)
 NEW_SOLUTION=$(find "$PWD" -type f -iname "*.slnx" | head -1)
 [ -z "$NEW_SOLUTION" ] || die "SolutionX found in $(pwd)"
 
+info "Migrating ${LEGACY_SOLUTION} to slnx format"
+
 dotnet sln migrate || die "Migration failed"
 
 NEW_SOLUTION=$(find "$PWD" -type f -iname "*.slnx" | head -1)
 [ -z "$NEW_SOLUTION" ] && die "No SolutionX found in $(pwd) after migration"
-
-echo ""
 
 if [ -f "$NEW_SOLUTION" ]; then
   [ -f "$LEGACY_SOLUTION" ] && rm -f "$LEGACY_SOLUTION"
   [ -f "$LEGACY_SOLUTION.DotSettings" ] && mv "$LEGACY_SOLUTION.DotSettings" "$NEW_SOLUTION.DotSettings"
   [ -f "$LEGACY_SOLUTION.DotSettings.user" ] && mv "$LEGACY_SOLUTION.DotSettings.user" "$NEW_SOLUTION.DotSettings.user"
 fi
- 
+
+success "Migration complete: ${NEW_SOLUTION}"


### PR DESCRIPTION
## Summary

- Replace the custom `die()` implementation with the standard `die`, `success`, and `info` output helpers as per project shell-script rules
- Remove bare `echo ""` blank line (the helpers already prefix output with a newline)
- Add `info` message before migration to announce progress
- Add `success` message on completion to confirm the result

Closes #633

## Test plan

- [x] `shellcheck` passes on the updated script
- [x] `checkbashisms` passes on the updated script
- [ ] Run script manually against a `.sln`-based solution and confirm `info`/`success` output appears
- [ ] Confirm that a failed `dotnet sln migrate` invocation triggers the `die` error message and exits non-zero