### PR TITLE
fix: replace raw echo with output helpers in development/restore-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replaced raw echo with output helpers in general/install-dotnet-tools
 - Replace raw echo with output helpers in general/convert-video
 - Replace raw echo with output helpers in development/sln-migrate
+- Replace raw echo with output helpers in development/restore-all
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/development/restore-all
+++ b/development/restore-all
@@ -1,10 +1,40 @@
 #! /bin/sh
 
-echo "Clearing nuget cache"
+die() {
+    if [ -t 2 ]; then
+        printf '\n\033[31m✗\033[0m %s\n' "$*" >&2
+    else
+        printf '\n✗ %s\n' "$*" >&2
+    fi
+    exit 1
+}
+
+success() {
+    if [ -t 1 ]; then
+        printf '\n\033[32m✓\033[0m %s\n' "$*"
+    else
+        printf '\n✓ %s\n' "$*"
+    fi
+}
+
+info() {
+    if [ -t 1 ]; then
+        printf '\n\033[32m→\033[0m %s\n' "$*"
+    else
+        printf '\n→ %s\n' "$*"
+    fi
+}
+
+info "Clearing nuget cache"
 dotnet nuget locals all --clear
 
-echo "Restoring packages"
+info "Restoring packages"
 find "$HOME/work" -iname global.json | while read -r key; do
-  CURRENT_DIR=$(dirname "$key");
-  echo "* $CURRENT_DIR:" &&  cd "$CURRENT_DIR" && dotnet restore && echo "   * done" || echo "   * failed";     
-done 
+  CURRENT_DIR=$(dirname "$key")
+  info "Restoring $CURRENT_DIR"
+  if (cd "$CURRENT_DIR" && dotnet restore); then
+    success "Restored $CURRENT_DIR"
+  else
+    die "Failed to restore $CURRENT_DIR"
+  fi
+done


### PR DESCRIPTION
## Summary

- Add `die`, `success`, and `info` output helpers to `development/restore-all`
- Replace all bare `echo` calls with the appropriate helpers for consistent, colour-aware output
- Wrap `cd` in a subshell per iteration to prevent directory-change leakage between loop iterations

Closes #632

## Test plan

- [ ] Script passes `shellcheck`
- [ ] `info` appears for progress messages (clearing cache, per-directory restore)
- [ ] `success` appears on a successful restore
- [ ] `die` appears and exits on a failed restore