### PR TITLE
feat: delegate buildcheck and buildtest to global hooks when available

### DIFF
--- a/development/buildcheck
+++ b/development/buildcheck
@@ -25,10 +25,14 @@ info() {
     fi
 }
 
-GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 SCRIPT_NAME=$(basename "$0")
+GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
     exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+fi
+SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
+if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
+    exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
 fi
 
 SOLUTION=$(find "$PWD" -type f -iname "*.sln" | head -1)

--- a/development/buildcheck
+++ b/development/buildcheck
@@ -27,14 +27,20 @@ info() {
 
 SCRIPT_NAME=$(basename "$0")
 GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
-if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
-    info "Using global pre-commit script: $GLOBAL_HOOKS/$SCRIPT_NAME"
-    exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+if [ -n "$GLOBAL_HOOKS" ]; then
+    GLOBAL_SCRIPTS=$(dirname "$GLOBAL_HOOKS")/scripts
+    if [ -x "$GLOBAL_SCRIPTS/$SCRIPT_NAME" ]; then
+        info "Using global pre-commit script: $GLOBAL_SCRIPTS/$SCRIPT_NAME"
+        exec "$GLOBAL_SCRIPTS/$SCRIPT_NAME" "$@"
+    fi
 fi
 SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
-if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
-    info "Using system pre-commit script: $SYSTEM_HOOKS/$SCRIPT_NAME"
-    exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
+if [ -n "$SYSTEM_HOOKS" ]; then
+    SYSTEM_SCRIPTS=$(dirname "$SYSTEM_HOOKS")/scripts
+    if [ -x "$SYSTEM_SCRIPTS/$SCRIPT_NAME" ]; then
+        info "Using system pre-commit script: $SYSTEM_SCRIPTS/$SCRIPT_NAME"
+        exec "$SYSTEM_SCRIPTS/$SCRIPT_NAME" "$@"
+    fi
 fi
 info "Using local $SCRIPT_NAME"
 

--- a/development/buildcheck
+++ b/development/buildcheck
@@ -28,12 +28,15 @@ info() {
 SCRIPT_NAME=$(basename "$0")
 GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
+    info "Using global pre-commit script: $GLOBAL_HOOKS/$SCRIPT_NAME"
     exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
 fi
 SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
 if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
+    info "Using system pre-commit script: $SYSTEM_HOOKS/$SCRIPT_NAME"
     exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
 fi
+info "Using local $SCRIPT_NAME"
 
 SOLUTION=$(find "$PWD" -type f -iname "*.sln" | head -1)
 [ -z "$SOLUTION" ] && SOLUTION=$(find "$PWD" -type f -iname "*.slnx" | head -1)

--- a/development/buildcheck
+++ b/development/buildcheck
@@ -25,6 +25,12 @@ info() {
     fi
 }
 
+GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
+SCRIPT_NAME=$(basename "$0")
+if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
+    exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+fi
+
 SOLUTION=$(find "$PWD" -type f -iname "*.sln" | head -1)
 [ -z "$SOLUTION" ] && SOLUTION=$(find "$PWD" -type f -iname "*.slnx" | head -1)
 [ -z "$SOLUTION" ] && die "No Solution found in $(pwd)"

--- a/development/buildtest
+++ b/development/buildtest
@@ -29,14 +29,20 @@ BASEDIR=$(dirname "$(readlink -f "$0")")
 
 SCRIPT_NAME=$(basename "$0")
 GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
-if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
-    info "Using global pre-commit script: $GLOBAL_HOOKS/$SCRIPT_NAME"
-    exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+if [ -n "$GLOBAL_HOOKS" ]; then
+    GLOBAL_SCRIPTS=$(dirname "$GLOBAL_HOOKS")/scripts
+    if [ -x "$GLOBAL_SCRIPTS/$SCRIPT_NAME" ]; then
+        info "Using global pre-commit script: $GLOBAL_SCRIPTS/$SCRIPT_NAME"
+        exec "$GLOBAL_SCRIPTS/$SCRIPT_NAME" "$@"
+    fi
 fi
 SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
-if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
-    info "Using system pre-commit script: $SYSTEM_HOOKS/$SCRIPT_NAME"
-    exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
+if [ -n "$SYSTEM_HOOKS" ]; then
+    SYSTEM_SCRIPTS=$(dirname "$SYSTEM_HOOKS")/scripts
+    if [ -x "$SYSTEM_SCRIPTS/$SCRIPT_NAME" ]; then
+        info "Using system pre-commit script: $SYSTEM_SCRIPTS/$SCRIPT_NAME"
+        exec "$SYSTEM_SCRIPTS/$SCRIPT_NAME" "$@"
+    fi
 fi
 info "Using local $SCRIPT_NAME"
 

--- a/development/buildtest
+++ b/development/buildtest
@@ -33,7 +33,7 @@ if [ -n "$GLOBAL_HOOKS" ]; then
     GLOBAL_SCRIPTS=$(dirname "$GLOBAL_HOOKS")/scripts
     if [ -x "$GLOBAL_SCRIPTS/$SCRIPT_NAME" ]; then
         info "Using global pre-commit script: $GLOBAL_SCRIPTS/$SCRIPT_NAME"
-        exec "$GLOBAL_SCRIPTS/$SCRIPT_NAME" "$@"
+        buildcheck && exec "$GLOBAL_SCRIPTS/$SCRIPT_NAME" "$@"
     fi
 fi
 SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
@@ -41,7 +41,7 @@ if [ -n "$SYSTEM_HOOKS" ]; then
     SYSTEM_SCRIPTS=$(dirname "$SYSTEM_HOOKS")/scripts
     if [ -x "$SYSTEM_SCRIPTS/$SCRIPT_NAME" ]; then
         info "Using system pre-commit script: $SYSTEM_SCRIPTS/$SCRIPT_NAME"
-        exec "$SYSTEM_SCRIPTS/$SCRIPT_NAME" "$@"
+        buildcheck && exec "$SYSTEM_SCRIPTS/$SCRIPT_NAME" "$@"
     fi
 fi
 info "Using local $SCRIPT_NAME"

--- a/development/buildtest
+++ b/development/buildtest
@@ -30,12 +30,15 @@ BASEDIR=$(dirname "$(readlink -f "$0")")
 SCRIPT_NAME=$(basename "$0")
 GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
+    info "Using global pre-commit script: $GLOBAL_HOOKS/$SCRIPT_NAME"
     exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
 fi
 SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
 if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
+    info "Using system pre-commit script: $SYSTEM_HOOKS/$SCRIPT_NAME"
     exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
 fi
+info "Using local $SCRIPT_NAME"
 
 RULESET_ADJUSTMENT_FILE=
 TEST_BENCHMARKS=

--- a/development/buildtest
+++ b/development/buildtest
@@ -27,10 +27,14 @@ info() {
 
 BASEDIR=$(dirname "$(readlink -f "$0")")
 
-GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 SCRIPT_NAME=$(basename "$0")
+GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
 if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
     exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+fi
+SYSTEM_HOOKS=$(git config --system core.hooksPath 2>/dev/null)
+if [ -n "$SYSTEM_HOOKS" ] && [ -x "$SYSTEM_HOOKS/$SCRIPT_NAME" ]; then
+    exec "$SYSTEM_HOOKS/$SCRIPT_NAME" "$@"
 fi
 
 RULESET_ADJUSTMENT_FILE=

--- a/development/buildtest
+++ b/development/buildtest
@@ -27,6 +27,12 @@ info() {
 
 BASEDIR=$(dirname "$(readlink -f "$0")")
 
+GLOBAL_HOOKS=$(git config --global core.hooksPath 2>/dev/null)
+SCRIPT_NAME=$(basename "$0")
+if [ -n "$GLOBAL_HOOKS" ] && [ -x "$GLOBAL_HOOKS/$SCRIPT_NAME" ]; then
+    exec "$GLOBAL_HOOKS/$SCRIPT_NAME" "$@"
+fi
+
 RULESET_ADJUSTMENT_FILE=
 TEST_BENCHMARKS=
 TEST_INTEGRATION=


### PR DESCRIPTION
## Summary

- `buildcheck` and `buildtest` now check `git config --global core.hooksPath` at startup
- If the path is set and the hooks directory contains a matching executable script, `exec` delegates to it instead of running local logic
- Falls through to the existing implementation when no global override is present

Closes #696

## Test plan

- [ ] Verify scripts still work normally when `core.hooksPath` is not set
- [ ] Verify scripts delegate correctly when `core.hooksPath` points to a directory containing `buildcheck`/`buildtest`