### PR TITLE
fix: replace raw echo with output helpers in db/dbappsettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - Replace raw echo with output helpers in db/install-mssql
 - Replace raw echo with output helpers in db/dropmssqldb
 - Replace raw echo with output helpers in db/dbenv
+- Replace raw echo with output helpers in db/dbappsettings
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/db/dbappsettings
+++ b/db/dbappsettings
@@ -1,21 +1,14 @@
 #!/bin/sh
 
 BASEDIR="$(dirname "$(readlink -f "$0")")"
-
-die() {
-    echo
-    echo "$@"
-    exit 1
-}
-
-BASEDIR="$(dirname "$(readlink -f "$0")")"
-echo "Script Dir: $BASEDIR"
 SERVER=
 DB=
 
-# Not following: 
+# Not following:
 # shellcheck disable=1091
-. "$BASEDIR/dbenv" 
+. "$BASEDIR/dbenv"
+
+info "Script Dir: $BASEDIR"
 
 [ -z "$SERVER" ] && die "--server not specified"
 [ -z "$DB" ] && die "--database not specified"
@@ -24,25 +17,22 @@ DB=
 
 for  CSPROJ in $(find "$PWD" -iname "*.csproj") IFS='\n'; do
   PROJECT_DIR="$(dirname "$CSPROJ")"
-#  echo "Checking $PROJECT_DIR..."
   APPSETTINGS_FILE="$PROJECT_DIR/appsettings.json"
-  LOCAL_APPSETTINGS_FILE="$PROJECT_DIR/appsettings-local.json"  
-  
+  LOCAL_APPSETTINGS_FILE="$PROJECT_DIR/appsettings-local.json"
+
   if [  -f "$APPSETTINGS_FILE" ]; then
-    echo "* Found $APPSETTINGS_FILE"
+    info "Found $APPSETTINGS_FILE"
     if [ ! -f "$LOCAL_APPSETTINGS_FILE" ]; then
-      echo "* Creating $LOCAL_APPSETTINGS_FILE..."
+      info "Creating $LOCAL_APPSETTINGS_FILE..."
       cat << EOF > "$LOCAL_APPSETTINGS_FILE"
 {"DatabaseConfiguration": {"Provider":"","ConnectionString":""}}
 EOF
     else
-      echo "* Existing $LOCAL_APPSETTINGS_FILE..."
+      info "Existing $LOCAL_APPSETTINGS_FILE..."
     fi
-      
-    cat "$LOCAL_APPSETTINGS_FILE" | \
-      jq --arg Provider "mssql" '.DatabaseConfiguration.Provider=$Provider' | \
+
+    jq --arg Provider "mssql" '.DatabaseConfiguration.Provider=$Provider' "$LOCAL_APPSETTINGS_FILE" | \
       jq --arg ConnectionString "Database=$DB;Server=$SERVER;User ID=$USER;Password=$PASSWORD;Application Name=$DB;Connection Timeout=60;TrustServerCertificate=true" '.DatabaseConfiguration.ConnectionString=$ConnectionString' | \
       tee "$LOCAL_APPSETTINGS_FILE"
   fi
 done
-


### PR DESCRIPTION
## Summary

- Removed the non-standard `die()` implementation and duplicate `BASEDIR` assignment
- Sourced `dbenv` first so the standard `die`, `info`, and `success` helpers are available
- Replaced all `echo` calls with `info` for progress output
- Fixed useless `cat` (SC2002) by passing the file directly to `jq`

Closes #622