### PR TITLE
fix: buildtest --no-benchmarks/--no-integration flag typos and broken TEST_INTEGRATION assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - git/fetch and git/switchtomain now warn and skip a repo on error instead of aborting the whole run, so remaining repos still get processed.
 - development/buildtest now runs unit tests first, always excluding benchmark test projects, then runs any benchmark projects found individually without the --long-running/--parallel-algorithm flags, since some benchmark projects' test host rejects them as invalid arguments (exit code 5, zero tests ran) instead of running
 - development/buildtest: fixed the --no-benchmarks/--no-integration flag typos and the broken TEST_INTEGRATION filter assignment so --no-integration actually excludes integration tests
+- development/buildtest: disable shell pathname expansion (set -f) around the dotnet test invocation using the unquoted TEST_INTEGRATION filter, so a *.Integration.Tests(.*) file in the solution directory can no longer glob-expand and corrupt the --no-integration filter arguments
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 -->
@@ -50,6 +53,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - git/ignore-changelog: skip push hooks when pushing to target repositories
 - git/fetch and git/switchtomain now warn and skip a repo on error instead of aborting the whole run, so remaining repos still get processed.
 - development/buildtest now runs unit tests first, always excluding benchmark test projects, then runs any benchmark projects found individually without the --long-running/--parallel-algorithm flags, since some benchmark projects' test host rejects them as invalid arguments (exit code 5, zero tests ran) instead of running
+- development/buildtest: fixed the --no-benchmarks/--no-integration flag typos and the broken TEST_INTEGRATION filter assignment so --no-integration actually excludes integration tests
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/development/buildtest
+++ b/development/buildtest
@@ -171,6 +171,10 @@ info "Testing..."
 # credfeto/credfeto-global-pre-commit - that repo is the source of truth for
 # this design; this file is a local fork/vendored copy, not consumed
 # directly from there (see credfeto/scripts#679, credfeto/scripts#723).
+# set -f disables pathname expansion for the unquoted $TEST_INTEGRATION below,
+# so a *.Integration.Tests(.*) file sitting in $SOURCE_DIR can't get glob-expanded
+# in place of the literal filter pattern; word splitting still applies.
+set -f
 # shellcheck disable=SC2086
 dotnet test \
           --configuration Release \
@@ -191,6 +195,7 @@ dotnet test \
           "-p:SuppressNETCoreSdkPreviewMessage=true" \
           "-p:Version=0.0.0.1-test" \
           || die "Tests Failed"
+set +f
 
 if [ -z "$TEST_BENCHMARKS" ]; then
   BENCH_PROJECTS=$(find "$SOURCE_DIR" -type f -iname "*.csproj" -not -path "*/obj/*" -not -path "*/bin/*" | while IFS= read -r proj; do

--- a/development/buildtest
+++ b/development/buildtest
@@ -66,12 +66,12 @@ while [ $# -gt 0 ]; do
       [ -f "$SOURCE_DIR/release.rule-settings.json" ] && RULESET_ADJUSTMENT_FILE="$SOURCE_DIR/release.rule-settings.json"
       shift # past argument
       ;;
-    -b|--no-benchmmarks)
+    -b|--no-benchmarks)
       TEST_BENCHMARKS=1
       shift # past argument
       ;;
-    -i|--no-integratopn)
-      TEST_INTEGRATION=--filter-not-namespace "*.Integration.Tests" --filter-not-namespace "*.Integration.Tests.*"
+    -i|--no-integration)
+      TEST_INTEGRATION="--filter-not-namespace *.Integration.Tests --filter-not-namespace *.Integration.Tests.*"
       shift # past argument
       ;;
     *)    # unknown option
@@ -162,7 +162,7 @@ dotnet build \
 
 info "Testing..."
 # Every benchmark test project is always excluded here, regardless of the
-# -b/--no-benchmmarks flag; benchmarks (if any) are run separately below, one
+# -b/--no-benchmarks flag; benchmarks (if any) are run separately below, one
 # project per dotnet test invocation, since some benchmark projects' test
 # host rejects --long-running/--parallel-algorithm as invalid arguments when
 # passed to a combined run.


### PR DESCRIPTION
## Summary

Scaffolding PR for #679. The original OOM root cause (--parallel-algorithm aggressive racing benchmark assemblies against unit tests) is already fixed on main by #723's commit 6e022f58: the main dotnet test pass now always excludes every benchmark test project, and benchmark projects (if any) are run individually afterwards.

## Remaining scope for this PR

In development/buildtest:

1. Fix the flag typos:
   - -b|--no-benchmmarks becomes -b|--no-benchmarks (line 69, plus the matching comment reference at line ~165)
   - -i|--no-integratopn becomes -i|--no-integration (line 73)
2. Fix the still-broken TEST_INTEGRATION assignment (line 74):

   TEST_INTEGRATION=--filter-not-namespace "*.Integration.Tests" --filter-not-namespace "*.Integration.Tests.*"

   This is parsed by sh as an env-var-prefixed command invocation (*.Integration.Tests as a command name), not a simple assignment, so --no-integration/-i is currently a silent no-op. Suggested fix, mirroring the style already used for the (now-fixed) TEST_BENCHMARKS variable and the existing "shellcheck disable=SC2086" on the dotnet test invocation that consumes it unquoted:

   TEST_INTEGRATION="--filter-not-namespace *.Integration.Tests --filter-not-namespace *.Integration.Tests.*"

   No open PR/caller in this repo passes -b/-i today (confirmed via search), so renaming the flags is safe.

Verified: shellcheck development/buildtest is clean both before and after this class of change; no .csproj/.sln in this repo (shell-scripts-only, so no dotnet buildcheck applies).

## Out of scope / needs follow-up

credfeto asked (issue comment, 2026-07-19) whether --parallel-algorithm sequential (and --long-running) could be reintroduced for the per-project benchmark dotnet test invocation, ideally as part of this issue's scope. This can't be verified from within credfeto/scripts itself - there are no benchmark test projects here - and prior direct evidence (#723's issue body, commit a0bf8ee1) showed at least one real benchmark project's test host rejects those flags outright (exit code 5, "Zero tests ran") when run standalone. Recommend validating this against a real benchmark project (e.g. in funfair-server-ethereum) before deciding whether to add it back; flagging here rather than silently narrowing scope.

## Test strategy

- shellcheck development/buildtest after the fix
- Manual inspection that $TEST_INTEGRATION word-splits into exactly the four intended arguments when passed unquoted to dotnet test

Closes #679
