### PR TITLE
chore: pin GitHub Actions uses: references to commit SHA instead of tag

### DIFF
--- a/.github/workflows/geoipupdate.yml
+++ b/.github/workflows/geoipupdate.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: "Get Latest source"
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
           token: ${{ secrets.SOURCE_PUSH_TOKEN }}
       - name: "Detect dotnet version"
-        uses: credfeto/action-dotnet-version-detect@v1.3.0
+        uses: credfeto/action-dotnet-version-detect@d572bbd7285038bda731c8a4f237b9b8e64a9954 # v1.3.0
       - name: "Install dotnet"
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.SOURCE_PUSH_TOKEN }}
         with:
@@ -70,7 +70,7 @@ jobs:
         env:
           CURRENT_DATE: ${{steps.time.outputs.CURRENT_DATE}}
       - name: "Commit changes"
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: "[GEOIP] - Updated GEOIP DB from MaxMind (${{steps.time.outputs.CURRENT_DATE}})"
           file_pattern: "*.mmdb CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
+- Pin GitHub Actions uses: references to commit SHAs instead of mutable tags in geoipupdate.yml
 ### Added
 - fetch: added --switch-to-main flag to switch to the default branch and rebase it when not on it, skipping if there are uncommitted changes
 - git/ignore-changelog: script to add CHANGELOG.md to .markdownlintignore across git repositories


### PR DESCRIPTION
## Summary

Part of an org-wide audit of `.github/workflows/*.yml` and `.github/actions/*/action.yml` files for GitHub Actions referenced by a mutable tag instead of a full commit SHA. A tag can be repointed by the upstream maintainer, or an attacker who compromises their account, without warning; a commit SHA is immutable.

This PR will pin the four `uses:` references in `.github/workflows/geoipupdate.yml` to their immutable commit SHAs, keeping the released version as a trailing comment:

- `actions/checkout@v7.0.1` -> `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/setup-dotnet@v6` -> `actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6`
- `credfeto/action-dotnet-version-detect@v1.3.0` -> `credfeto/action-dotnet-version-detect@d572bbd7285038bda731c8a4f237b9b8e64a9954 # v1.3.0`
- `stefanzweifel/git-auto-commit-action@v7` -> `stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7`

All four SHAs have been independently verified against the upstream repositories' tags (`git ls-remote --tags`) and match exactly.

## Test strategy

- `actionlint` / repo YAML lint against the edited workflow.
- Verify each SHA resolves to the stated tag upstream (done above).

Closes #728