### PR TITLE
fix(git/fetch): report a fetch/skip summary instead of raw errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 - development/buildtest now runs unit tests first, always excluding benchmark test projects, then runs any benchmark projects found individually without the --long-running/--parallel-algorithm flags, since some benchmark projects' test host rejects them as invalid arguments (exit code 5, zero tests ran) instead of running
 - development/buildtest: fixed the --no-benchmarks/--no-integration flag typos and the broken TEST_INTEGRATION filter assignment so --no-integration actually excludes integration tests
 - development/buildtest: disable shell pathname expansion (set -f) around the dotnet test invocation using the unquoted TEST_INTEGRATION filter, so a *.Integration.Tests(.*) file in the solution directory can no longer glob-expand and corrupt the --no-integration filter arguments
+- git/fetch no longer prints raw git/ssh errors when a repo can't be reached, and reports a fetched/skipped summary at the end
 ### Changed
 - Replace raw echo with standard output helpers (die/info/success) in github/cancel-workflows
 - Replace raw echo with standard output helpers (die/info/success) in git/update-repos-personal

--- a/git/fetch
+++ b/git/fetch
@@ -42,7 +42,16 @@ for arg in "$@"; do
     esac
 done
 
-find "$(pwd)"/* -name '*.git' -print | sed "s|/.git$||" | sort -u | grep -v .cache | while IFS= read -r line
+REPO_LIST=$(mktemp)
+trap 'rm -f "$REPO_LIST"' EXIT
+
+find "$(pwd)"/* -name '*.git' -print | sed "s|/.git$||" | sort -u | grep -v .cache > "$REPO_LIST"
+
+FETCHED_COUNT=0
+SKIPPED_COUNT=0
+SKIPPED_REPOS=""
+
+while IFS= read -r line
 do
   CURRENT_DIR=$line
 
@@ -53,11 +62,15 @@ do
   else
     git -C "$CURRENT_DIR" config --local --unset core.hookspath 2>/dev/null || true
   fi
-  git -C "$CURRENT_DIR" remote get-url origin 2>&1 || { warn "Could not determine origin for ${CURRENT_DIR}"; continue; }
-  git -C "$CURRENT_DIR" fetch --prune --prune-tags 2>&1 || { warn "Could not fetch ${CURRENT_DIR}"; continue; }
-  git -C "$CURRENT_DIR" remote update origin --prune 2>&1 || { warn "Could not update remote refs for ${CURRENT_DIR}"; continue; }
+  git -C "$CURRENT_DIR" remote get-url origin > /dev/null 2>&1 || { warn "Could not determine origin for ${CURRENT_DIR}"; SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); SKIPPED_REPOS="${SKIPPED_REPOS}${CURRENT_DIR} (could not determine origin)
+"; continue; }
+  git -C "$CURRENT_DIR" fetch --prune --prune-tags > /dev/null 2>&1 || { warn "Could not fetch ${CURRENT_DIR}"; SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); SKIPPED_REPOS="${SKIPPED_REPOS}${CURRENT_DIR} (could not fetch)
+"; continue; }
+  git -C "$CURRENT_DIR" remote update origin --prune > /dev/null 2>&1 || { warn "Could not update remote refs for ${CURRENT_DIR}"; SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); SKIPPED_REPOS="${SKIPPED_REPOS}${CURRENT_DIR} (could not update remote refs)
+"; continue; }
 
-  REPO_STATUS=$(git -C "$CURRENT_DIR" status --porcelain 2>&1) || { warn "Could not read status for ${CURRENT_DIR}"; continue; }
+  REPO_STATUS=$(git -C "$CURRENT_DIR" status --porcelain 2>&1) || { warn "Could not read status for ${CURRENT_DIR}"; SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); SKIPPED_REPOS="${SKIPPED_REPOS}${CURRENT_DIR} (could not read status)
+"; continue; }
 
   if [ -z "$REPO_STATUS" ]
   then
@@ -75,7 +88,8 @@ do
 
   if [ "$SWITCH_TO_MAIN" = "1" ]
   then
-    CURRENT_BRANCH=$(git -C "$CURRENT_DIR" rev-parse --abbrev-ref HEAD 2>&1) || { warn "Could not determine current branch for ${CURRENT_DIR}"; continue; }
+    CURRENT_BRANCH=$(git -C "$CURRENT_DIR" rev-parse --abbrev-ref HEAD 2>&1) || { warn "Could not determine current branch for ${CURRENT_DIR}"; SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); SKIPPED_REPOS="${SKIPPED_REPOS}${CURRENT_DIR} (could not determine current branch)
+"; continue; }
     DEFAULT_BRANCH=$(git -C "$CURRENT_DIR" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
 
     if [ -z "$DEFAULT_BRANCH" ]
@@ -106,5 +120,13 @@ do
     fi
   fi
 
+  FETCHED_COUNT=$((FETCHED_COUNT + 1))
   success "Done with ${CURRENT_DIR}"
-done
+done < "$REPO_LIST"
+
+info "${FETCHED_COUNT} repo(s) fetched, ${SKIPPED_COUNT} repo(s) skipped"
+if [ "$SKIPPED_COUNT" -gt 0 ]
+then
+  warn "Skipped repositories:"
+  printf '%s' "$SKIPPED_REPOS" >&2
+fi


### PR DESCRIPTION
## Summary
- The `fetch` script already skips a repo it can't reach (e.g. no publickey access) via `continue`, but the raw git/ssh failure text printed to the terminal made a normal skip look like a crash.
- Redirects each origin/fetch/update-check's stdout+stderr to `/dev/null`, keeping the existing `warn` message as the only output on failure.
- Switches the main loop to read the repo list from a temp file instead of a pipe, so per-run counters aren't lost in a subshell.
- Prints a final summary line (`N repo(s) fetched, M repo(s) skipped`) plus the list of skipped repos with reasons.

## Test plan
- [x] `shellcheck -s sh git/fetch` passes
- [x] pre-commit hook passes on the branch